### PR TITLE
fix do not run build step twice

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,3 @@
 test:
   pre:
     - make bootstrap
-    - make build


### PR DESCRIPTION
because of:
```
// Makefile
bootstrap:
  npm install
  node scripts/bootstrap.js
  scripts/build.sh
```
[Makefile#L16](https://github.com/flintjs/flint/blob/241bc5acbe1bfb765c49a195ded8669013c06550/Makefile#L16)