### PR TITLE
Surge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 deps/
 out/
 .tmp
+.flint

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,7 @@
     "reapp-object-assign": "^1.0.0",
     "replace": "^0.3.0",
     "rimraf": "^2.2.8",
-    "surge": "0.17.6"
+    "surge": "0.17.7"
   },
   "bin": {
     "flint": "./entry/flint",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,8 @@
     "raven": "^0.8.1",
     "reapp-object-assign": "^1.0.0",
     "replace": "^0.3.0",
-    "rimraf": "^2.2.8"
+    "rimraf": "^2.2.8",
+    "surge": "0.17.6"
   },
   "bin": {
     "flint": "./entry/flint",

--- a/packages/cli/src/bin/flint.js
+++ b/packages/cli/src/bin/flint.js
@@ -2,6 +2,8 @@
 
 var Program = require('commander')
 var colors = require('colors')
+var Surge = require('surge')
+var surge = new Surge
 
 /* START -- make `flint run` default command -- */
 var flintIndex = getFlintIndex()
@@ -44,6 +46,25 @@ exec(checkversion, (err, version) => {
     }
   }
 })
+
+Program
+  .command('whoami')
+  .description('see who you are logged in as')
+  .action(surge.whoami({}))
+
+Program
+  .command('login')
+  .description('login to upload flint apps')
+  .action(surge.login({}))
+
+Program
+  .command('logout')
+  .action(surge.logout({}))
+
+Program
+  .command('teardown')
+  .description('tear down an uploaded flint app')
+  .action(surge.teardown({}))
 
 Program
   .version(require('../../package.json').version)

--- a/packages/cli/src/bin/flint.js
+++ b/packages/cli/src/bin/flint.js
@@ -74,6 +74,12 @@ Program
   .action(surge.list(hooks))
 
 Program
+  .command('up')
+  .description('upload a project via Surge')
+  .action(surge.publish(hooks))
+
+
+Program
   .command('plus [domain]')
   .description('upgrade a project to Surge Plus')
   .action(surge.plus(hooks))

--- a/packages/cli/src/bin/flint.js
+++ b/packages/cli/src/bin/flint.js
@@ -3,7 +3,8 @@
 var Program = require('commander')
 var colors = require('colors')
 var Surge = require('surge')
-var surge = new Surge
+var hooks = require('../hooks.js')
+var surge = Surge({ platform: 'roguemont.com' })
 
 /* START -- make `flint run` default command -- */
 var flintIndex = getFlintIndex()
@@ -50,21 +51,32 @@ exec(checkversion, (err, version) => {
 Program
   .command('whoami')
   .description('see who you are logged in as')
-  .action(surge.whoami({}))
+  .action(surge.whoami(hooks))
 
 Program
   .command('login')
   .description('login to upload flint apps')
-  .action(surge.login({}))
+  .action(surge.login(hooks))
 
 Program
   .command('logout')
-  .action(surge.logout({}))
+  .description('log out of your account')
+  .action(surge.logout(hooks))
 
 Program
-  .command('teardown')
+  .command('teardown [domain]')
   .description('tear down an uploaded flint app')
-  .action(surge.teardown({}))
+  .action(surge.teardown(hooks))
+
+Program
+  .command('list')
+  .description('List all the projects you’ve published')
+  .action(surge.list(hooks))
+
+Program
+  .command('plus [domain]')
+  .description('upgrade a project to Surge Plus')
+  .action(surge.plus(hooks))
 
 Program
   .version(require('../../package.json').version)

--- a/packages/cli/src/hooks.js
+++ b/packages/cli/src/hooks.js
@@ -1,5 +1,11 @@
 // Pre- and post-action hooks for Surge
 
+var Program = require('commander')
+var runner = require('flint-runner')
+var colors = require('colors')
+var fs = require('fs')
+var path = require('path')
+
 module.exports = {
   preAuth: function (req, resume) {
     resume()
@@ -8,7 +14,37 @@ module.exports = {
     resume()
   },
   preProject: function (req, resume) {
-    resume()
+    fs.stat(process.cwd() + '/.flint', function(err, res) {
+      var buildDir = path.resolve(process.cwd(), '.flint', 'build')
+
+      if (err || !res) {
+        console.log("\nRun 'flint' in a flint repo to start your development server.".green.bold)
+      }
+
+      /**
+       * Do the Flint compile step here!
+       * This is an example where we create
+       * a new `200.html` file if there isn’t one,
+       * where client side routing
+       * and then publish it to Surge.
+       *
+       * You can replace it with your compile step:
+       * await runner.build({ once: true })
+       */
+
+      fs.writeFile(path.resolve(buildDir, '200.html'), '<h1>Hello Flint on ' + new Date().toJSON() + '</h1>', function (err) {
+        if (err) throw err
+
+        /**
+         * IMPORTANT
+         * We set `req.project` so Surge doesn’t
+         * prompt the user for their project dir
+         */
+
+        req.project = buildDir
+        resume()
+      })
+    })
   },
   postProject: function (req, resume) {
     resume()

--- a/packages/cli/src/hooks.js
+++ b/packages/cli/src/hooks.js
@@ -1,0 +1,34 @@
+// Pre- and post-action hooks for Surge
+
+module.exports = {
+  preAuth: function (req, resume) {
+    resume()
+  },
+  postAuth: function (req, resume) {
+    resume()
+  },
+  preProject: function (req, resume) {
+    resume()
+  },
+  postProject: function (req, resume) {
+    resume()
+  },
+  preSize: function (req, resume) {
+    resume()
+  },
+  postSize: function (req, resume) {
+    resume()
+  },
+  preDomain: function (req, resume) {
+    resume()
+  },
+  postDomain: function (req, resume) {
+    resume()
+  },
+  prePublish: function (req, resume) {
+    resume()
+  },
+  postPublish: function (req, resume) {
+    resume()
+  }
+}

--- a/packages/flint-runner/npm-shrinkwrap.json
+++ b/packages/flint-runner/npm-shrinkwrap.json
@@ -6730,9 +6730,9 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
     },
     "surge": {
-      "version": "0.17.4",
+      "version": "0.17.6",
       "from": "surge@latest",
-      "resolved": "https://registry.npmjs.org/surge/-/surge-0.17.4.tgz",
+      "resolved": "https://registry.npmjs.org/surge/-/surge-0.17.6.tgz",
       "dependencies": {
         "asn1": {
           "version": "0.1.11",

--- a/packages/flint-runner/package.json
+++ b/packages/flint-runner/package.json
@@ -61,7 +61,7 @@
     "strip-ansi": "^3.0.0",
     "style-loader": "^0.13.0",
     "sudo": "^1.0.3",
-    "surge": "^0.17.6",
+    "surge": "^0.17.7",
     "through2": "^2.0.0",
     "uglify-js": "^2.5.0",
     "url-loader": "^0.5.7",

--- a/packages/flint-runner/package.json
+++ b/packages/flint-runner/package.json
@@ -61,7 +61,7 @@
     "strip-ansi": "^3.0.0",
     "style-loader": "^0.13.0",
     "sudo": "^1.0.3",
-    "surge": "^0.17.4",
+    "surge": "^0.17.6",
     "through2": "^2.0.0",
     "uglify-js": "^2.5.0",
     "url-loader": "^0.5.7",

--- a/packages/flint-runner/src/keys.js
+++ b/packages/flint-runner/src/keys.js
@@ -15,9 +15,42 @@ const proc = process // cache for keypress
 
 import Surge from 'surge'
 const out = proc.stdout
-const surge = Surge({ platform: 'flint.love', input: proc.stdin, output: out })
+const surge = Surge({
+  platform: 'roguemont.com',
+  input: proc.stdin,
+  output: out
+})
 
+let hooks = {
+  preAuth: function (req, resume) {
+    out.isTTY = false
+    resume()
+  },
+  postAuth: function (req, resume) {
+    out.isTTY = true
+    resume()
+  },
+  preDomain: function (req, resume) {
+    out.isTTY = false
+    resume()
+  },
+  postDomain: function (req, resume) {
+    out.isTTY = true
+    resume()
+  }
+}
 let stopped = false
+
+// hooks.preAuth() {
+//   out.isTTY = false
+// }
+//
+//
+// hooks.postPublish() {
+//   console.log('🚀🚀🚀🚀')
+//   resume()
+// }
+
 
 export function init() {
   start()
@@ -90,13 +123,32 @@ function start() {
           console.log(`\n  Publishing to surge...`)
           stop()
           out.isTTY = false
-          surge.publish({
-            postPublish() {
-              console.log('🚀🚀🚀🚀')
-              resume()
-            }
-          })({})
+          surge.publish(hooks)({
+            project: '.flint/build',
+            domain: 'my-flint-test.roguemont.com'
+          })
           out.isTTY = true
+          break
+        case 'w': // See who you are logged in as
+          stop()
+          console.log(hooks)
+          surge.whoami(hooks)({})
+          // resume()
+          break
+        case 'l': // List all your published projects
+          surge.list(hooks)({})
+          break
+        case '>':
+          surge.login(hooks)({})
+          break
+        case '<':
+          surge.logout(hooks)({})
+          break
+        case 'x': // Teardown a published project
+          surge.teardown(hooks)({})
+          break
+        case '+': // Upgrade a published project
+          surge.plus(hooks)({})
           break
         case 'd':
           console.log("---------opts---------")


### PR DESCRIPTION
**For review**

This pull request adds the Surge integration, which makes it possible to publish Flint apps via Surge.

![flint-3](https://cloud.githubusercontent.com/assets/1581276/12436945/5d84aa72-bece-11e5-9d25-ef8dcf2d2fe0.gif)

- [x] Add `flint whoami`
- [x] Add `flint teardown`
- [x] Add `flint list`
- [x] Add `flint login`
- [x] Add `flint logout`
- [x] Add `flint plus`
- [x] Adds `flint up` uploading command with example
- [x] Update minor fixes in Surge, tag and publish v0.17.7 (@kennethormandy, @sintaxi)
- [ ] Fix update notifier so it doesn’t conflict with `flint up`, etc.
- [ ] Re-shrinkwrap dependencies
- [ ] Improve `u` upload command when just running Surge (@kennethormandy)
- [ ] Replace example in `flint up` with real Flint compile step
- [ ] Update config, which is currently set to `roguemont.com`, to `flint.loves` once the DNS, etc. are pointed at Surge
